### PR TITLE
일정 삭제 및 로컬 DB 연동 개선

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -135,9 +135,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     child: const Icon(Icons.delete, color: Colors.white),
                   ),
-                  onDismissed: (_) {
+                  onDismissed: (_) async {
+                    // Dismissible이 제거된 뒤에도 위젯 트리에 남아있는 오류를 방지하기 위해
+                    // 먼저 저장소에서 일정을 삭제한 뒤 setState로 화면을 갱신합니다.
+                    await repo.deleteEvent(e.id); // 로컬 DB에서 일정 삭제
                     setState(() {
-                      repo.deleteEvent(e.id); // 일정 삭제
                       _remainMap.remove(e.id); // 남은 시간 정보도 제거
                       if (_taskId == e.id) {
                         _stopEvent(); // 실행 중인 일정이 삭제되면 중지


### PR DESCRIPTION
## Summary
- Dismissible에서 일정 삭제 시 위젯이 남는 오류를 비동기 처리로 해결하고 설명 주석을 추가했습니다.
- Drift를 이용해 로컬 DB와 일정 CRUD를 연동하여 저장/삭제가 정상 동작하도록 수정했습니다.

## Testing
- `flutter test` *(실행 불가: flutter 명령어 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68c421f10b04832594629b59d85036da