### PR TITLE
일정 수정 기능과 배터리 선택 드롭다운, 시간 포맷 개선 및 종료 알림

### DIFF
--- a/lib/features/event/edit_event_screen.dart
+++ b/lib/features/event/edit_event_screen.dart
@@ -4,28 +4,50 @@ import '../../data/models.dart';
 import '../../data/repositories.dart';
 import '../../core/compute.dart';
 
-/// 일정 등록 화면
-/// - 제목, 내용, 소요 시간, 배터리 변화를 입력받아 이벤트를 저장
+/// 일정 등록/수정 화면
+/// - 제목, 내용, 소요 시간, 배터리 변화를 입력받아 이벤트를 저장하거나 수정
 class EditEventScreen extends ConsumerStatefulWidget {
-  const EditEventScreen({super.key});
+  /// [event]가 null이면 신규 등록, null이 아니면 해당 일정을 수정
+  const EditEventScreen({super.key, this.event});
+
+  /// 수정 대상 일정 (없으면 새 일정 등록 모드)
+  final Event? event;
 
   @override
   ConsumerState<EditEventScreen> createState() => _EditEventState();
 }
 
 class _EditEventState extends ConsumerState<EditEventScreen> {
-  final _formKey = GlobalKey<FormState>();
+  final _formKey = GlobalKey<FormState>(); // 폼 상태 관리 키
 
-  String _title = ''; // 일정 제목 저장 변수
-  String _content = ''; // 일정 설명 저장 변수
+  // --- 사용자가 입력할 값들 ---
+  String _title = ''; // 일정 제목
+  String _content = ''; // 일정 설명
   int _minutes = 0; // 소요 시간(분)
-  double _battery = 0.0; // 전체 배터리 변화 퍼센트 (초기값 0.0)
+  double _battery = 0.0; // 배터리 변화량(절대값, 양수만 저장)
+  bool _isCharge = false; // true=충전, false=소모 (기본값: 소모)
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.event; // 전달받은 일정이 있는지 확인
+    if (e != null) {
+      // 기존 일정 정보를 입력 폼에 미리 채워 넣는다.
+      _title = e.title;
+      _content = e.content ?? '';
+      _minutes = e.endAt.difference(e.startAt).inMinutes;
+      final total = (e.ratePerHour ?? 0) * (_minutes / 60); // 전체 배터리 변화량
+      _isCharge = total >= 0; // 0 이상이면 충전, 음수면 소모
+      _battery = total.abs(); // 표시를 위해 절대값 사용
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final repo = ref.watch(repositoryProvider); // 리포지토리 접근
     return Scaffold(
-      appBar: AppBar(title: const Text('일정 등록')),
+      appBar: AppBar(
+          title: Text(widget.event == null ? '일정 등록' : '일정 수정')),
       body: Form(
         key: _formKey,
         child: ListView(
@@ -34,52 +56,85 @@ class _EditEventState extends ConsumerState<EditEventScreen> {
             // 제목 입력 필드
             TextFormField(
               decoration: const InputDecoration(labelText: '제목'),
+              initialValue: _title,
               onChanged: (v) => _title = v,
             ),
             // 내용(상세 설명) 입력 필드
             TextFormField(
               decoration: const InputDecoration(labelText: '내용'),
+              initialValue: _content,
               onChanged: (v) => _content = v,
             ),
             // 소요 시간 입력 필드 (분 단위)
             TextFormField(
               decoration: const InputDecoration(labelText: '소요 시간(분)'),
               keyboardType: TextInputType.number,
+              initialValue: _minutes == 0 ? '' : _minutes.toString(),
               onChanged: (v) => _minutes = int.tryParse(v) ?? 0,
             ),
-            // 배터리 변화 입력 필드 (양수=충전, 음수=소모)
-            TextFormField(
-              decoration: const InputDecoration(labelText: '배터리 변화(%)'),
-              keyboardType: TextInputType.number,
-              onChanged: (v) =>
-                  _battery = double.tryParse(v) ?? 0.0, // 숫자 변환 실패 시 0.0으로 처리
+            // 배터리 변화 입력 (충전/소모 선택 + 퍼센트)
+            Row(
+              children: [
+                // 충전/소모 선택 드롭다운
+                Expanded(
+                  flex: 2,
+                  child: DropdownButtonFormField<bool>(
+                    decoration: const InputDecoration(labelText: '종류'),
+                    value: _isCharge,
+                    items: const [
+                      DropdownMenuItem(value: false, child: Text('소모')),
+                      DropdownMenuItem(value: true, child: Text('충전')),
+                    ],
+                    onChanged: (v) => setState(() => _isCharge = v ?? false),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // 배터리 변화량 입력 (양수만 입력)
+                Expanded(
+                  flex: 3,
+                  child: TextFormField(
+                    decoration:
+                        const InputDecoration(labelText: '배터리 변화(%)'),
+                    keyboardType: TextInputType.number,
+                    initialValue: _battery == 0 ? '' : _battery.toString(),
+                    onChanged: (v) =>
+                        _battery = double.tryParse(v) ?? 0.0, // 숫자 변환 실패 시 0.0
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 20),
             // 저장 버튼
             ElevatedButton(
               onPressed: () {
-                final start = DateTime.now(); // 시작 시각은 현재로 설정
+                final start =
+                    widget.event?.startAt ?? DateTime.now(); // 기존 일정이면 시작 시각 유지
                 final end = start.add(Duration(minutes: _minutes)); // 종료 시각 계산
+                final change =
+                    _isCharge ? _battery : -_battery; // 선택에 따라 부호 결정
                 final double rate = _minutes > 0
-                    ? _battery / (_minutes / 60)
+                    ? change / (_minutes / 60)
                     : 0.0; // 0.0을 사용해 double 타입 유지
-                // 이벤트 생성
+
+                // 이벤트 생성 (신규/수정 공용)
                 final e = Event(
-                  id: DateTime.now().microsecondsSinceEpoch.toString(),
+                  id: widget.event?.id ??
+                      DateTime.now().microsecondsSinceEpoch.toString(),
                   title: _title,
                   content: _content,
                   startAt: start,
                   endAt: end,
-                  type: EventType.neutral, // 기본 타입은 중립
+                  type: widget.event?.type ?? EventType.neutral,
                   ratePerHour: rate,
-                  priority: defaultPriority(EventType.neutral),
-                  createdAt: DateTime.now(),
+                  priority:
+                      widget.event?.priority ?? defaultPriority(EventType.neutral),
+                  createdAt: widget.event?.createdAt ?? DateTime.now(),
                   updatedAt: DateTime.now(),
                 );
-                repo.saveEvent(e); // 이벤트 저장
+                repo.saveEvent(e); // 이벤트 저장/수정
                 Navigator.pop(context); // 이전 화면으로 복귀
               },
-              child: const Text('저장'),
+              child: Text(widget.event == null ? '저장' : '수정'),
             )
           ],
         ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -7,6 +7,8 @@ import 'battery_gauge.dart';
 import 'battery_controller.dart';
 import '../../data/repositories.dart';
 import '../../data/models.dart'; // Event 모델 사용을 위해 추가
+import '../../services/notifications.dart'; // 알림 서비스
+import '../event/edit_event_screen.dart'; // 일정 수정 화면
 
 /// 홈 화면
 /// - 등록된 일정 목록을 보여주고 스와이프로 삭제 가능
@@ -164,11 +166,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     Future.microtask(_loadState);
   }
 
-  /// Duration을 "HH:mm" 형식의 문자열로 변환
+  /// Duration을 "HH:mm:ss" 형식의 문자열로 변환
   String _format(Duration d) {
     final h = d.inHours.toString().padLeft(2, '0');
     final m = (d.inMinutes % 60).toString().padLeft(2, '0');
-    return '$h:$m';
+    final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$h:$m:$s';
   }
 
   /// 일정 시작 처리
@@ -188,9 +191,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
 
     // 배터리 컨트롤러에 작업 시작 요청
+    // 배터리 컨트롤러에 작업 시작 요청
     ref
         .read(batteryControllerProvider.notifier)
         .startTask(ratePerHour: e.ratePerHour ?? 0, duration: duration);
+
+    // 기존에 예약된 알림이 있다면 취소 후 새로 예약
+    final notif = ref.read(notificationProvider);
+    await notif.cancel(e.id.hashCode);
+    await notif.scheduleComplete(
+      id: e.id.hashCode,
+      title: '일정 완료',
+      body: '${e.title}이(가) 완료되었습니다',
+      after: duration,
+    );
 
     // 시작한 작업 정보를 로컬 저장소에 기록
     _remainMap[e.id] = duration;
@@ -205,7 +219,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     });
     _countdown = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (_remain.inSeconds <= 1) {
-        _stopEvent(); // 시간이 끝나면 작업 종료
+        _stopEvent(completed: true); // 시간이 끝나면 작업 종료
       } else {
         setState(() {
           _remain -= const Duration(seconds: 1);
@@ -215,9 +229,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   /// 일정 중지 처리
-  Future<void> _stopEvent() async {
+  /// - [completed] true이면 정상 완료, false이면 사용자가 중지
+  Future<void> _stopEvent({bool completed = false}) async {
     ref.read(batteryControllerProvider.notifier).stop();
     _countdown?.cancel();
+
+    // 사용자가 중지한 경우 예약된 알림 취소
+    if (!completed && _taskId != null) {
+      await ref.read(notificationProvider).cancel(_taskId!.hashCode);
+    }
+
     setState(() {
       if (_taskId != null) {
         // 중지 시점의 남은 시간을 저장해 다음 시작에 활용
@@ -306,7 +327,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       children: [
                         if (e.content != null && e.content!.isNotEmpty)
                           Text(e.content!), // 일정 상세 내용
-                        Text('소요 시간: ${base.inMinutes}분'),
+                        Text('소요 시간: ${_format(base)}'),
                         Text('배터리 변화: ${total.toStringAsFixed(1)}%'),
                         if (running)
                           Text(
@@ -315,15 +336,42 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           ), // 실행 중이면 남은 시간 표시
                       ],
                     ),
-                    trailing: ElevatedButton(
-                      onPressed: () async {
-                        if (running) {
-                          await _stopEvent();
-                        } else {
-                          await _startEvent(e);
-                        }
-                      },
-                      child: Text(running ? '중지' : '시작'),
+                    // 시작/중지 버튼과 수정 버튼을 나란히 배치
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // 수정 버튼
+                        IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: () async {
+                            // 수정 화면으로 이동 후 돌아오면 목록 갱신
+                            await Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => EditEventScreen(event: e),
+                              ),
+                            );
+                            // 수정된 일정의 기본 시간으로 남은 시간을 재설정
+                            setState(() {
+                              final updated = repo.events
+                                  .firstWhere((ev) => ev.id == e.id);
+                              _remainMap[e.id] =
+                                  updated.endAt.difference(updated.startAt);
+                            });
+                            await _saveRemainMap(); // 변경 사항 저장
+                          },
+                        ),
+                        ElevatedButton(
+                          onPressed: () async {
+                            if (running) {
+                              await _stopEvent();
+                            } else {
+                              await _startEvent(e);
+                            }
+                          },
+                          child: Text(running ? '중지' : '시작'),
+                        ),
+                      ],
                     ),
                   ),
                 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   intl: ^0.19.0
   flutter_local_notifications: ^17.2.3
   shared_preferences: ^2.2.2
+  timezone: ^0.9.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- 남은 시간을 HH:MM:ss 형식으로 표시하고 일정 소요 시간도 동일하게 출력
- 일정 완료 알림을 예약해 앱이 종료되어도 알림을 수신하도록 구현
- 예약 알림을 위해 timezone 의존성을 추가

## Testing
- `dart format lib/features/home/home_screen.dart lib/services/notifications.dart pubspec.yaml` *(실패: dart 명령어를 찾을 수 없음)*
- `flutter test` *(실패: flutter 명령어를 찾을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68c43986b428832582aa754b81fc389c