### PR TITLE
알림 권한 요청 기능 추가

### DIFF
--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -14,7 +14,13 @@ class NotificationService {
     // 안드로이드용 기본 아이콘 설정
     const android = AndroidInitializationSettings('@mipmap/ic_launcher');
     // iOS와 macOS가 공통으로 사용하는 초기화 설정
-    const darwin = DarwinInitializationSettings();
+    const darwin = DarwinInitializationSettings(
+      // iOS/macOS는 처음 실행 시 사용자에게 알림 권한을 요청해야 함
+      // 아래 옵션들을 true로 지정하면 앱 시작과 동시에 권한 창이 뜬다
+      requestAlertPermission: true, // 화면에 알림 배너를 띄울 수 있는지
+      requestBadgePermission: true, // 앱 아이콘에 숫자 뱃지를 표시할 수 있는지
+      requestSoundPermission: true, // 알림 시 소리를 재생할 수 있는지
+    );
     // 플랫폼별 설정을 하나로 묶어서 전달
     const init = InitializationSettings(
       android: android,
@@ -23,6 +29,19 @@ class NotificationService {
     );
     // 플러그인 실제 초기화 수행
     await _plugin.initialize(init);
+
+    // 안드로이드 13(API 33) 이상에서는 알림 권한이 기본적으로 꺼져 있으므로
+    // 명시적으로 사용자에게 권한 허용을 요청한다
+    await _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestPermission();
+
+    // iOS와 macOS에서도 알림, 뱃지, 소리 권한을 각각 요청해야 함
+    await _plugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(alert: true, sound: true, badge: true);
   }
 
   /// 배터리가 부족할 때 보여주는 간단한 알림


### PR DESCRIPTION
## 요약
- Darwin 초기화 설정에 알림, 뱃지, 소리 권한 요청 옵션 추가
- 초기화 이후 안드로이드 13 이상 및 iOS/macOS에서 알림 권한 요청 수행

## 테스트
- `flutter test` (실패: flutter 명령어를 찾을 수 없음)


------
https://chatgpt.com/codex/tasks/task_e_68c43f3264e48325b5d06b6a31a8daca