### PR TITLE
홈 화면 원형 배터리 크기 30% 축소

### DIFF
--- a/lib/features/home/life_battery_home_screen.dart
+++ b/lib/features/home/life_battery_home_screen.dart
@@ -380,18 +380,22 @@ class _CircularBattery extends StatelessWidget {
 
   const _CircularBattery({required this.percent});
 
+  // 원형 배터리 전체 크기
+  // 기존 220px에서 30% 줄인 154px를 사용한다.
+  static const double _gaugeSize = 154;
+
   @override
   Widget build(BuildContext context) {
-    // 디자인 시안과 동일하게 220x220 크기의 원형 게이지를 사용한다.
+    // 디자인 시안(220x220)에서 30% 축소된 154x154 크기의 원형 게이지를 사용한다.
     return SizedBox(
-      width: 220,
-      height: 220,
+      width: _gaugeSize,
+      height: _gaugeSize,
       child: Stack(
         alignment: Alignment.center,
         children: [
           // 연한 배경 원 (전체 100%)
           CustomPaint(
-            size: const Size(220, 220),
+            size: const Size(_gaugeSize, _gaugeSize),
             painter: _CirclePainter(
               progress: 1,
               color: const Color(0xFFEAE6FF), // 옅은 보라색
@@ -399,7 +403,7 @@ class _CircularBattery extends StatelessWidget {
           ),
           // 실제 퍼센트만큼 채워지는 보라색 원호
           CustomPaint(
-            size: const Size(220, 220),
+            size: const Size(_gaugeSize, _gaugeSize),
             painter: _CirclePainter(
               progress: percent,
               color: const Color(0xFF9B51E0), // 진한 보라색
@@ -576,7 +580,8 @@ class _CirclePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    const strokeWidth = 16.0; // 선의 두께 (디자인 시안과 동일)
+    // 선 두께도 전체 크기 축소 비율(30%)에 맞춰 11.2로 조정
+    const strokeWidth = 11.2; // 기존 16에서 30% 줄인 값
     final center = Offset(size.width / 2, size.height / 2);
     final radius = min(size.width, size.height) / 2 - strokeWidth / 2;
 


### PR DESCRIPTION
## 요약
- 홈 화면의 원형 배터리 게이지를 기존 220px에서 154px로 축소
- 게이지 축소에 맞춰 선 두께도 11.2로 조정

## 테스트
- `flutter test` (명령어를 찾을 수 없음)


------
https://chatgpt.com/codex/tasks/task_e_68c5a36f8d4883258791deb80c40f9f0