### PR TITLE
충전 전·중 아크 위치 동일화

### DIFF
--- a/lib/features/home/widgets/mag_safe_aura.dart
+++ b/lib/features/home/widgets/mag_safe_aura.dart
@@ -33,28 +33,35 @@ class MagSafeAura extends StatelessWidget {
     final sigma = ring.thickness * 0.9;       // 블러 강도
     final size = ring.size;                   // 링의 지름
 
+    // 위젯 전체 크기를 링 지름으로 고정하여
+    // 충전 전/중에 위치가 달라지지 않도록 한다.
     return IgnorePointer(
-      child: Stack(
-        alignment: Alignment.center,
-        clipBehavior: Clip.none,
-        children: [
-          // ★ 외곽에만 퍼지는 글로우 스트로크 (안쪽은 절대 채우지 않음)
-          CustomPaint(
-            // 블러가 바깥으로 퍼지므로 캔버스를 두께만큼 키워서 잘림을 방지한다.
-            size: Size.square(size + glowWidth * 2),
-            painter: _OuterGlowPainter(
-              // 확대된 캔버스에서 링의 위치를 옮겨 그린다.
-              rect: ring.rect.shift(Offset(glowWidth, glowWidth)),
-              strokeWidth: glowWidth,
-              color: glowColor.withOpacity(0.85),
-              sigma: sigma,
+      child: SizedBox.square(
+        dimension: size,
+        child: Stack(
+          alignment: Alignment.center,
+          clipBehavior: Clip.none, // 글로우가 바깥으로 퍼져도 잘리지 않도록 함
+          children: [
+            // ★ 외곽으로만 퍼지는 글로우 스트로크
+            CustomPaint(
+              // 캔버스 크기를 링 지름으로 유지하여 위치를 통일한다.
+              size: Size.square(size),
+              painter: _OuterGlowPainter(
+                // ring.rect를 그대로 사용하여 ChargingRing과 동일한 좌표계를 공유
+                rect: ring.rect,
+                strokeWidth: glowWidth,
+                color: glowColor.withOpacity(0.85),
+                sigma: sigma,
+              ),
             ),
-          ),
-          if (showBolt)
-            Icon(Icons.bolt_rounded,
+            if (showBolt)
+              Icon(
+                Icons.bolt_rounded,
                 size: boltSize,
-                color: glowColor.withOpacity(0.9)),
-        ],
+                color: glowColor.withOpacity(0.9),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/widgets/mag_safe_charging_ring.dart
+++ b/lib/features/home/widgets/mag_safe_charging_ring.dart
@@ -49,38 +49,43 @@ class MagSafeChargingRing extends StatelessWidget {
     )
         : null; // 비충전: ChargingRing의 기본 퍼센트 텍스트 사용
 
-    return Stack(
-      alignment: Alignment.center,
-      clipBehavior: Clip.none,
-      children: [
-        if (charging)
-          IgnorePointer(
-            child: MagSafeAura(
-              ring: ring,
-              glowColor: const Color(0x9934C759),
-              highlight: const Color(0xFF34C759),
-              // MagSafeAura에서 번개 아이콘을 숨겨 중복되는 표시를 방지
-              showBolt: false,
+    // Stack을 고정 크기 박스로 감싸 충전 여부와 상관없이
+    // 위치가 변하지 않도록 한다.
+    return SizedBox.square(
+      dimension: size,
+      child: Stack(
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
+        children: [
+          if (charging)
+            IgnorePointer(
+              child: MagSafeAura(
+                ring: ring,
+                glowColor: const Color(0x9934C759),
+                highlight: const Color(0xFF34C759),
+                // MagSafeAura에서 번개 아이콘을 숨겨 중복되는 표시를 방지
+                showBolt: false,
+              ),
             ),
-          ),
-        ChargingRing(
-          percent: p,
-          ring: ring,
-          labelFont: labelFont,
-          center: center, // 중앙은 여기서만 그린다 (중복 X)
+          ChargingRing(
+            percent: p,
+            ring: ring,
+            labelFont: labelFont,
+            center: center, // 중앙은 여기서만 그린다 (중복 X)
 
-          // 색상: 비충전(보라 그라데이션) / 충전(녹색 단색)
-          trackColor: charging
-              ? const Color(0xFFE6E8ED)
-              : const Color(0xFFE9E8FF),
-          progressStart: charging
-              ? const Color(0xFF34C759)
-              : const Color(0xFFC8B6FF),
-          progressEnd: charging
-              ? const Color(0xFF34C759) // start=end → 단색 효과
-              : const Color(0xFF5B2EFF),
-        ),
-      ],
+            // 색상: 비충전(보라 그라데이션) / 충전(녹색 단색)
+            trackColor: charging
+                ? const Color(0xFFE6E8ED)
+                : const Color(0xFFE9E8FF),
+            progressStart: charging
+                ? const Color(0xFF34C759)
+                : const Color(0xFFC8B6FF),
+            progressEnd: charging
+                ? const Color(0xFF34C759) // start=end → 단색 효과
+                : const Color(0xFF5B2EFF),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## 개요
- MagSafe 오라와 충전 링의 크기를 고정해 위치가 달라지지 않도록 수정
- 충전 상태에 따라 위젯 크기가 변해 생기던 어긋남 해소

## 테스트
- `flutter test` (명령어 없음)
- `dart test` (명령어 없음)
- `apt-get update` (저장소 인증 실패)


------
https://chatgpt.com/codex/tasks/task_e_68c6f5de374883259e975c045c964612