### PR TITLE
feat: 일정 편집 저장 시 안전한 화면 이동

### DIFF
--- a/lib/features/schedule/schedule_detail_screen.dart
+++ b/lib/features/schedule/schedule_detail_screen.dart
@@ -29,7 +29,8 @@ class ScheduleDetailScreen extends ConsumerWidget {
         title: Text(schedule.title),
         actions: [
           IconButton(
-            onPressed: () => context.go('/schedule/${schedule.id}/edit'),
+            // 상세 화면에서 편집 화면으로 이동할 때는 push를 사용해 되돌아올 수 있도록 한다.
+            onPressed: () => context.push('/schedule/${schedule.id}/edit'),
             icon: const Icon(Icons.edit),
             tooltip: '수정',
           ),

--- a/lib/features/schedule/schedule_edit_screen.dart
+++ b/lib/features/schedule/schedule_edit_screen.dart
@@ -375,7 +375,24 @@ class _ScheduleEditScreenState extends ConsumerState<ScheduleEditScreen> {
     await manager.applySchedule(schedule);
     if (!mounted) return;
     setState(() => _loading = false);
-    context.pop();
+
+    // 저장 후 이동 경로를 결정하기 위해 현재 라우터와 편집 여부를 확인한다.
+    final router = GoRouter.of(context); // 화면 이동을 담당하는 GoRouter 인스턴스
+    final bool isEditing = widget.scheduleId != null; // 기존 일정을 수정 중인지 여부
+    final String destinationPath = '/schedule/${schedule.id}'; // 상세 화면 경로를 미리 만들어 둔다.
+
+    if (isEditing) {
+      // 상세 화면에서 push로 들어온 경우에는 pop으로 돌아가야 자연스럽다.
+      if (router.canPop()) {
+        router.pop(); // 스택에 이전 화면이 남아 있을 때는 해당 화면으로 되돌아간다.
+      } else {
+        // 딥링크나 go()로 진입해 스택이 비어 있으면 pop이 실패하므로, go()로 안전하게 이동한다.
+        router.go(destinationPath);
+      }
+    } else {
+      // 신규 생성 화면에서는 항상 저장한 일정의 상세 화면으로 이동한다.
+      router.go(destinationPath);
+    }
   }
 }
 


### PR DESCRIPTION
## 요약
- 일정 저장 후 편집/신규 흐름에 맞춰 라우터 이동을 안전하게 분기했습니다.
- 상세 화면에서 편집 화면 진입을 push로 변경해 자연스러운 복귀 흐름을 만들었습니다.

## 테스트
- flutter test (환경에 Flutter 미설치로 실행 불가)


------
https://chatgpt.com/codex/tasks/task_e_68c9b1e2421c83259a1c20ed3b65505c