### PR TITLE
feat: 라이프 배터리 홈에 위치 일정과 권한 처리 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'data/schedule_repository.dart';
 import 'features/schedule/providers.dart';
 import 'features/schedule/schedule_detail_screen.dart';
 import 'features/schedule/schedule_edit_screen.dart';
+import 'features/home/life_battery_home_screen.dart';
 import 'features/schedule/schedule_home_screen.dart';
 import 'features/settings/settings_screen.dart';
 import 'services/geofence_manager.dart';
@@ -57,7 +58,21 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/',
         name: 'home',
-        builder: (context, state) => const ScheduleHomeScreen(),
+        builder: (context, state) {
+          // ▼ 초보자도 이해하기 쉽게: 앱을 켰을 때 가장 먼저 보이는 화면을 지정한다.
+          //    기존에는 일정 홈(ScheduleHomeScreen)으로 이동했지만,
+          //    요청에 따라 라이프 배터리 홈(LifeBatteryHomeScreen)을 기본 화면으로 교체했다.
+          return const LifeBatteryHomeScreen();
+        },
+      ),
+      GoRoute(
+        path: '/schedule',
+        name: 'scheduleHome',
+        builder: (context, state) {
+          // ▼ 라이프 배터리 홈에서 일정 전용 화면으로 이동하고 싶을 때 사용할 라우트.
+          //    '/schedule' 경로로 이동하면 이전에 사용하던 일정 홈 UI를 그대로 확인할 수 있다.
+          return const ScheduleHomeScreen();
+        },
       ),
       GoRoute(
         path: '/schedule/new',


### PR DESCRIPTION
## Summary
- 라이프 배터리 홈에서 위치 권한 요청과 지오펜스 재동기화 로직을 실행하도록 구성했습니다.
- 기존 배터리 쇼케이스 디자인을 유지한 채 위치 기반 일정 리스트와 에러/빈 상태 안내 UI를 배치했습니다.
- 위치 일정 카드, 설정 이동, 새 일정 추가 등 상호작용을 홈 화면에서 바로 사용할 수 있게 했습니다.

## Testing
- `flutter test` *(환경에 flutter 명령어가 없어 실행하지 못했습니다)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b778a7c08325904a8486cec78631