### PR TITLE
feat: 지오펜스 자동 이벤트 실행 연동

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,19 @@ void main() async {
     repository: scheduleRepo,
     notificationService: notif,
   );
+  // Schedule.presetType에 따라 어떤 Event를 자동 실행해야 하는지 매핑한다.
+  geofenceManager.eventIdResolver = (schedule) {
+    switch (schedule.presetType) {
+      case SchedulePresetType.commuteIn:
+      case SchedulePresetType.commuteOut:
+        // 기본 제공 출근 이벤트와 연결한다. (퇴근도 동일 이벤트를 재사용)
+        return AppRepository.commuteEventId;
+      case SchedulePresetType.move:
+      case SchedulePresetType.workout:
+        // 아직은 대응되는 기본 Event가 없으므로 null을 반환해 자동 실행을 생략한다.
+        return null;
+    }
+  };
 
   runApp(
     ProviderScope(


### PR DESCRIPTION
## 요약
- 지오펜스 매니저에 이벤트 ID 매퍼와 트리거 스트림을 추가하고 로그를 강화했습니다.
- 홈 화면이 지오펜스 자동 실행 스트림을 구독하여 출근 이벤트를 자동 시작하고 일정 상태를 갱신합니다.
- 앱 진입 시 프리셋-이벤트 매핑 콜백을 주입해 출근/퇴근 일정이 올바른 이벤트로 연결되도록 구성했습니다.

## 테스트
- flutter test (환경에 flutter 명령이 없어 실행 불가)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2afd4c08325ae5d1d8d9dac4b95