### PR TITLE
feat: 업무 강도 기반 배터리 계산 개선

### DIFF
--- a/lib/features/event/edit_event_screen.dart
+++ b/lib/features/event/edit_event_screen.dart
@@ -135,6 +135,55 @@ class _ColorChoice extends StatelessWidget {
   }
 }
 
+/// 업무 강도 옵션을 정의하는 열거형
+///
+/// - 각 항목은 `시간당 배터리 변화량(ratePerHour)`을 고정값으로 제공한다.
+/// - 사용자는 이해하기 쉬운 라벨과 설명을 보고 적절한 강도를 선택한다.
+enum _IntensityLevel {
+  low, // 여유로운 업무 (낮은 소모)
+  medium, // 일반적인 업무
+  high, // 몰입이 필요한 고강도 업무
+}
+
+/// [_IntensityLevel]에 부가 정보를 제공하는 확장
+extension _IntensityLevelDescription on _IntensityLevel {
+  /// UI에 표시할 간단한 라벨
+  String get label {
+    switch (this) {
+      case _IntensityLevel.low:
+        return '여유로움';
+      case _IntensityLevel.medium:
+        return '보통';
+      case _IntensityLevel.high:
+        return '집중';
+    }
+  }
+
+  /// 사용자가 참고할 수 있는 상세 설명 (초보자 배려)
+  String get description {
+    switch (this) {
+      case _IntensityLevel.low:
+        return '간단한 확인 위주의 업무 (시간당 약 5%)';
+      case _IntensityLevel.medium:
+        return '일반적인 작업량 (시간당 약 10%)';
+      case _IntensityLevel.high:
+        return '고강도 집중 작업 (시간당 약 15%)';
+    }
+  }
+
+  /// 시간당 배터리 변화율(절대값) - %/h 단위
+  double get ratePerHour {
+    switch (this) {
+      case _IntensityLevel.low:
+        return 5.0;
+      case _IntensityLevel.medium:
+        return 10.0;
+      case _IntensityLevel.high:
+        return 15.0;
+    }
+  }
+}
+
 class _EditEventState extends ConsumerState<EditEventScreen> {
   final _formKey = GlobalKey<FormState>(); // 폼 상태 관리 키
 
@@ -146,6 +195,12 @@ class _EditEventState extends ConsumerState<EditEventScreen> {
   bool _isCharge = false; // true=충전, false=소모 (기본값: 소모)
   String _iconName = defaultEventIconName; // 선택된 아이콘 식별자 (문자열)
   String _colorName = defaultEventColorName; // 선택된 색상 식별자 (문자열)
+  bool _useManualBatteryInput = false; // 고급 옵션 사용 여부 (true면 직접 입력)
+  _IntensityLevel _selectedIntensity =
+      _IntensityLevel.medium; // 기본 업무 강도 (보통)
+
+  // 강도 추정 시 사용할 허용 오차 (floating point 보정용)
+  static const double _intensityTolerance = 0.01;
 
   @override
   void initState() {
@@ -161,7 +216,61 @@ class _EditEventState extends ConsumerState<EditEventScreen> {
       _battery = total.abs(); // 표시를 위해 절대값 사용
       _iconName = e.iconName; // 저장된 아이콘을 그대로 사용
       _colorName = e.colorName; // 저장된 색상도 함께 적용
+      final rate = (e.ratePerHour ?? 0).abs(); // 시간당 변화율의 절대값
+      final matched = _matchIntensity(rate); // 기존 일정의 강도를 역으로 추정
+      if (matched != null) {
+        _selectedIntensity = matched; // 추정이 가능한 경우 자동 계산 유지
+        _useManualBatteryInput = false;
+      } else {
+        _useManualBatteryInput = true; // 기존 수치가 표준 강도와 다르면 직접 입력으로 전환
+      }
+    } else {
+      _useManualBatteryInput = false; // 신규 등록 시 기본적으로 자동 계산 사용
     }
+  }
+
+  /// 저장된 시간당 변화율이 강도 옵션 중 하나와 가까운지 확인하는 헬퍼
+  _IntensityLevel? _matchIntensity(double rate) {
+    if (rate <= 0) {
+      return null; // 0 이하이면 강도를 추정할 수 없다.
+    }
+    for (final level in _IntensityLevel.values) {
+      if ((level.ratePerHour - rate).abs() < _intensityTolerance) {
+        return level; // 허용 오차 내에 있으면 해당 강도로 본다.
+      }
+    }
+    return null; // 어떤 강도와도 맞지 않는 경우 null 반환
+  }
+
+  /// 강도/시간/직접 입력 상태를 종합해 총 배터리 변화를 계산한다.
+  double _calculateBatteryChange() {
+    if (_minutes <= 0) {
+      return 0.0; // 시간이 0이면 변화도 0으로 간주
+    }
+    if (_useManualBatteryInput) {
+      final manual = _battery <= 0 ? 0.0 : _battery; // 음수 또는 0 이하 입력은 0으로 처리
+      return _isCharge ? manual : -manual; // 충전/소모 선택에 따라 부호 적용
+    }
+    final intensityRate = _selectedIntensity.ratePerHour; // 선택된 강도의 시간당 변화율
+    final hours = _minutes / 60.0; // 분 단위를 시간 단위로 변환
+    final change = intensityRate * hours; // 절대값 기준 변화량 계산
+    return _isCharge ? change : -change; // 충전 시 양수, 소모 시 음수
+  }
+
+  /// 미리보기 텍스트를 사용자 친화적으로 생성한다.
+  String _buildBatteryPreviewText() {
+    if (_minutes <= 0) {
+      return '예상 배터리 변화: 시간을 입력하면 자동 계산됩니다.';
+    }
+    final change = _calculateBatteryChange();
+    if (change == 0) {
+      return '예상 배터리 변화: 변화 없음 (입력값을 확인해 주세요)';
+    }
+    final action = change > 0 ? '충전' : '소모';
+    final sign = change > 0 ? '+' : '-';
+    final amount = change.abs();
+    final perHour = amount / (_minutes / 60.0);
+    return '예상 배터리 변화: $action $sign${amount.toStringAsFixed(1)}% (시간당 $sign${perHour.toStringAsFixed(1)}%)';
   }
 
   @override
@@ -192,36 +301,102 @@ class _EditEventState extends ConsumerState<EditEventScreen> {
               decoration: const InputDecoration(labelText: '소요 시간(분)'),
               keyboardType: TextInputType.number,
               initialValue: _minutes == 0 ? '' : _minutes.toString(),
-              onChanged: (v) => _minutes = int.tryParse(v) ?? 0,
+              onChanged: (v) {
+                setState(() {
+                  _minutes = int.tryParse(v) ?? 0; // 값이 바뀌면 즉시 상태 갱신
+                });
+              },
+              validator: (v) {
+                if (v == null || v.isEmpty) {
+                  return '소요 시간을 입력해주세요.'; // 필수 입력 안내
+                }
+                final parsed = int.tryParse(v);
+                if (parsed == null || parsed <= 0) {
+                  return '1분 이상의 숫자를 입력해주세요.'; // 음수/0 방지
+                }
+                return null;
+              },
             ),
-            // 배터리 변화 입력 (충전/소모 선택 + 퍼센트)
-            Row(
+            const SizedBox(height: 12),
+            // 배터리 변화 입력 (충전/소모 + 자동 계산 및 직접 입력 토글)
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // 충전/소모 선택 드롭다운
-                Expanded(
-                  flex: 2,
-                  child: DropdownButtonFormField<bool>(
-                    decoration: const InputDecoration(labelText: '종류'),
-                    value: _isCharge,
-                    items: const [
-                      DropdownMenuItem(value: false, child: Text('소모')),
-                      DropdownMenuItem(value: true, child: Text('충전')),
-                    ],
-                    onChanged: (v) => setState(() => _isCharge = v ?? false),
-                  ),
+                DropdownButtonFormField<bool>(
+                  decoration: const InputDecoration(labelText: '종류'),
+                  value: _isCharge,
+                  items: const [
+                    DropdownMenuItem(value: false, child: Text('소모')),
+                    DropdownMenuItem(value: true, child: Text('충전')),
+                  ],
+                  onChanged: (v) {
+                    setState(() => _isCharge = v ?? false); // 부호 선택도 즉시 반영
+                  },
                 ),
-                const SizedBox(width: 8),
-                // 배터리 변화량 입력 (양수만 입력)
-                Expanded(
-                  flex: 3,
-                  child: TextFormField(
+                const SizedBox(height: 12),
+                if (!_useManualBatteryInput) ...[
+                  const Text(
+                    '업무 강도 선택',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 4),
+                  // 라디오 버튼으로 강도를 선택해 자동 계산 값을 지정
+                  for (final level in _IntensityLevel.values)
+                    RadioListTile<_IntensityLevel>(
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(level.label),
+                      subtitle: Text(level.description),
+                      value: level,
+                      groupValue: _selectedIntensity,
+                      onChanged: (value) {
+                        if (value == null) {
+                          return;
+                        }
+                        setState(() => _selectedIntensity = value);
+                      },
+                    ),
+                ],
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('고급 옵션: 배터리 변화 직접 입력'),
+                  subtitle:
+                      const Text('자동 계산이 맞지 않을 때 수동으로 값을 설정하세요.'),
+                  value: _useManualBatteryInput,
+                  onChanged: (value) {
+                    setState(() => _useManualBatteryInput = value);
+                  },
+                ),
+                if (_useManualBatteryInput)
+                  TextFormField(
                     decoration:
                         const InputDecoration(labelText: '배터리 변화(%)'),
-                    keyboardType: TextInputType.number,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
                     initialValue: _battery == 0 ? '' : _battery.toString(),
-                    onChanged: (v) =>
-                        _battery = double.tryParse(v) ?? 0.0, // 숫자 변환 실패 시 0.0
+                    onChanged: (v) {
+                      setState(() {
+                        _battery =
+                            double.tryParse(v) ?? 0.0; // 숫자 변환 실패 시 0으로 처리
+                      });
+                    },
+                    validator: (v) {
+                      if (!_useManualBatteryInput) {
+                        return null; // 자동 계산 모드에서는 검증하지 않음
+                      }
+                      if (v == null || v.isEmpty) {
+                        return '배터리 변화량을 입력해주세요.';
+                      }
+                      final parsed = double.tryParse(v);
+                      if (parsed == null || parsed <= 0) {
+                        return '0보다 큰 숫자를 입력해주세요.';
+                      }
+                      return null;
+                    },
                   ),
+                const SizedBox(height: 8),
+                Text(
+                  _buildBatteryPreviewText(), // 실시간 미리보기 출력
+                  style: const TextStyle(color: Color(0xFF55586A)),
                 ),
               ],
             ),
@@ -281,14 +456,18 @@ class _EditEventState extends ConsumerState<EditEventScreen> {
             // 저장 버튼
             ElevatedButton(
               onPressed: () {
+                FocusScope.of(context).unfocus(); // 저장 시 키보드를 닫아준다.
+                if (!(_formKey.currentState?.validate() ?? false)) {
+                  return; // 검증 실패 시 저장을 중단한다.
+                }
+                final minutes = _minutes > 0 ? _minutes : 0; // 혹시 모를 음수 입력 방어
                 final start =
                     widget.event?.startAt ?? DateTime.now(); // 기존 일정이면 시작 시각 유지
-                final end = start.add(Duration(minutes: _minutes)); // 종료 시각 계산
-                final change =
-                    _isCharge ? _battery : -_battery; // 선택에 따라 부호 결정
-                final double rate = _minutes > 0
-                    ? change / (_minutes / 60)
-                    : 0.0; // 0.0을 사용해 double 타입 유지
+                final end = start.add(Duration(minutes: minutes)); // 종료 시각 계산
+                final change = _calculateBatteryChange(); // 총 배터리 변화(부호 포함)
+                final double rate = minutes > 0
+                    ? change / (minutes / 60)
+                    : 0.0; // 분 단위를 시간으로 환산해 시간당 변화율 산출
 
                 // 이벤트 생성 (신규/수정 공용)
                 final e = Event(


### PR DESCRIPTION
## 요약
- 업무 강도 선택을 위한 열거형과 상태를 추가하고 시간 기반 배터리 계산 로직을 재구성했습니다.
- 강도 라디오 버튼, 미리보기 텍스트, 수동 입력 토글을 포함한 UI를 구성하여 실시간 변화를 안내합니다.
- 저장 시 새 계산 결과를 활용하도록 이벤트 생성과 검증 흐름을 보강했습니다.

## 테스트
- flutter analyze *(명령어 부재로 실행 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c4eb3d548325b11f8e7c17cf3a8f