### PR TITLE
일정 등록 라우트에서 이벤트 편집 화면 사용

### DIFF
--- a/lib/data/repositories.dart
+++ b/lib/data/repositories.dart
@@ -36,6 +36,18 @@ class AppRepository extends ChangeNotifier {
   Map<String, String> eventIcons = {}; // 이벤트 ID별 아이콘 이름을 따로 저장
   Map<String, String> eventColors = {}; // 이벤트 ID별 색상 이름을 따로 저장
 
+  /// ID를 이용해 특정 이벤트를 찾아주는 헬퍼 메서드
+  ///
+  /// - 일정 상세 화면 등에서 전달받은 ID로 기존 데이터를 불러올 때 사용한다.
+  /// - 일치하는 일정이 없다면 null을 반환해 "신규 등록" 플로우가 자연스럽게 이어지도록 한다.
+  Event? findEventById(String id) {
+    try {
+      return events.firstWhere((event) => event.id == id);
+    } catch (_) {
+      return null; // 목록에 없으면 null을 반환해 호출측에서 후속 처리를 하도록 위임한다.
+    }
+  }
+
   // 특정 ID가 기본 제공 일정인지 확인하는 헬퍼. UI나 삭제 로직에서 재사용된다.
   bool isProtectedEvent(String id) => _protectedEventIds.contains(id);
 

--- a/lib/features/schedule/schedule_edit_screen.dart
+++ b/lib/features/schedule/schedule_edit_screen.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
-import 'package:latlong2/latlong.dart';
 
 import '../../data/schedule_models.dart';
 import '../../data/schedule_repository.dart';
 import '../../services/geofence_manager.dart';
+import 'widgets/map_preview.dart';
 import 'providers.dart';
 
 /// 일정 등록/수정 화면
@@ -396,71 +395,5 @@ class _ScheduleEditScreenState extends ConsumerState<ScheduleEditScreen> {
     } else {
       context.go('/');
     }
-  }
-}
-
-/// 간단한 지도 프리뷰(FlutterMap 기반)
-class MapPreview extends StatelessWidget {
-  const MapPreview({super.key, required this.lat, required this.lng, required this.radius});
-
-  final double? lat;
-  final double? lng;
-  final double radius;
-
-  @override
-  Widget build(BuildContext context) {
-    if (lat == null || lng == null) {
-      return Container(
-        height: 200,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: Colors.grey.shade200,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: const Text('좌표가 설정되면 지도가 표시됩니다.'),
-      );
-    }
-    final position = LatLng(lat!, lng!);
-    return SizedBox(
-      height: 220,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: FlutterMap(
-          options: MapOptions(
-            initialCenter: position,
-            initialZoom: 16,
-            interactionOptions: const InteractionOptions(
-              flags: InteractiveFlag.pinchZoom | InteractiveFlag.drag,
-            ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-              userAgentPackageName: 'com.example.energy_battery',
-            ),
-            CircleLayer(
-              circles: [
-                CircleMarker(
-                  point: position,
-                  color: Colors.blue.withOpacity(0.2),
-                  borderStrokeWidth: 2,
-                  borderColor: Colors.blue,
-                  useRadiusInMeter: true,
-                  radius: radius,
-                ),
-              ],
-            ),
-            MarkerLayer(
-              markers: [
-                Marker(
-                  point: position,
-                  child: const Icon(Icons.location_on, color: Colors.red, size: 36),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }

--- a/lib/features/schedule/widgets/map_preview.dart
+++ b/lib/features/schedule/widgets/map_preview.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+/// 지도 미리보기를 재사용하기 위한 위젯
+///
+/// - 위치 기반 일정 등록/수정 화면에서 지도 UI를 반복해서 작성하지 않도록 분리했다.
+/// - 초보자도 이해할 수 있도록, 좌표가 없을 때와 있을 때의 처리를 명확하게 주석으로 설명한다.
+class MapPreview extends StatelessWidget {
+  const MapPreview({
+    super.key,
+    required this.lat,
+    required this.lng,
+    required this.radius,
+  });
+
+  /// 표시할 위도. null이면 아직 좌표가 준비되지 않은 상태로 본다.
+  final double? lat;
+
+  /// 표시할 경도. null이면 아직 좌표가 준비되지 않은 상태로 본다.
+  final double? lng;
+
+  /// 반경(미터). 지도 위에 그려지는 원의 크기를 결정한다.
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    // 1) 좌표가 없는 경우: 사용자에게 안내 문구만 보여준다.
+    if (lat == null || lng == null) {
+      return Container(
+        height: 200,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade200,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Text('좌표가 설정되면 지도가 표시됩니다.'),
+      );
+    }
+
+    // 2) 좌표가 있는 경우: FlutterMap을 이용해 간단한 지도를 렌더링한다.
+    final position = LatLng(lat!, lng!);
+    return SizedBox(
+      height: 220,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: FlutterMap(
+          options: MapOptions(
+            initialCenter: position,
+            initialZoom: 16,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.pinchZoom | InteractiveFlag.drag,
+            ),
+          ),
+          children: [
+            // OpenStreetMap 타일을 이용해 기본 지도 배경을 구성한다.
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.example.energy_battery',
+            ),
+            // 사용자가 지정한 반경을 시각적으로 확인할 수 있도록 반투명 원을 추가한다.
+            CircleLayer(
+              circles: [
+                CircleMarker(
+                  point: position,
+                  color: Colors.blue.withOpacity(0.2),
+                  borderStrokeWidth: 2,
+                  borderColor: Colors.blue,
+                  useRadiusInMeter: true,
+                  radius: radius,
+                ),
+              ],
+            ),
+            // 중심 좌표에는 빨간 위치 아이콘을 표시해 시선을 집중시킨다.
+            MarkerLayer(
+              markers: [
+                Marker(
+                  point: position,
+                  child: const Icon(
+                    Icons.location_on,
+                    color: Colors.red,
+                    size: 36,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'core/compute.dart';
+import 'data/models.dart';
 import 'data/repositories.dart';
 import 'data/schedule_db.dart';
 import 'data/schedule_repository.dart';
+import 'features/event/edit_event_screen.dart';
 import 'features/schedule/providers.dart';
 import 'features/schedule/schedule_detail_screen.dart';
-import 'features/schedule/schedule_edit_screen.dart';
 import 'features/home/life_battery_home_screen.dart';
 import 'features/schedule/schedule_home_screen.dart';
 import 'features/settings/settings_screen.dart';
@@ -90,7 +92,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/schedule/new',
         name: 'scheduleNew',
-        builder: (context, state) => const ScheduleEditScreen(),
+        builder: (context, state) {
+          // ▼ 위치 기반 옵션이 포함된 새 일정 작성 화면을 `EditEventScreen`으로 통합했다.
+          //    이벤트와 지오펜스 정보를 한 번에 입력할 수 있도록 바로 해당 화면을 연다.
+          return const EditEventScreen();
+        },
       ),
       GoRoute(
         path: '/schedule/:id',
@@ -105,7 +111,71 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: 'scheduleEdit',
         builder: (context, state) {
           final id = state.pathParameters['id']!;
-          return ScheduleEditScreen(scheduleId: id);
+          // ▼ 기존 일정 수정 시에도 동일한 편집 화면을 사용한다.
+          //    Consumer를 이용해 Riverpod 상태를 구독하고, 저장된 이벤트/일정 정보를 불러온다.
+          return Consumer(
+            builder: (context, ref, _) {
+              final repo = ref.watch(repositoryProvider);
+              final asyncSchedules = ref.watch(scheduleStreamProvider);
+
+              // 1) 우선 이벤트 목록에서 동일 ID를 찾는다. (이전 통합 저장 구조와 호환)
+              final existingEvent = repo.findEventById(id);
+              if (existingEvent != null) {
+                return EditEventScreen(event: existingEvent);
+              }
+
+              // 2) 이벤트가 없을 경우, 기존 위치 기반 일정만 존재할 수 있으므로 스트림에서 찾아본다.
+              return asyncSchedules.when(
+                data: (items) {
+                  Schedule? schedule;
+                  for (final item in items) {
+                    if (item.id == id) {
+                      schedule = item;
+                      break;
+                    }
+                  }
+
+                  if (schedule != null) {
+                    // ▼ 일정 정보만 있을 때도 사용자가 당황하지 않도록, 임시 Event 데이터를 만들어 전달한다.
+                    final fallbackEvent = Event(
+                      id: schedule.id,
+                      title: schedule.title,
+                      content: schedule.placeName, // 장소명을 메모 용도로 채워준다.
+                      startAt: schedule.startAt,
+                      endAt: schedule.endAt,
+                      type: EventType.neutral,
+                      ratePerHour: 0,
+                      priority: defaultPriority(EventType.neutral),
+                      createdAt: schedule.createdAt,
+                      updatedAt: schedule.updatedAt,
+                      iconName:
+                          repo.eventIcons[schedule.id] ?? defaultEventIconName,
+                      colorName:
+                          repo.eventColors[schedule.id] ?? defaultEventColorName,
+                    );
+                    return EditEventScreen(event: fallbackEvent);
+                  }
+
+                  // 3) 어떤 정보도 없으면 안내 문구를 보여준다.
+                  return const Scaffold(
+                    body: Center(
+                      child: Text('해당 일정을 불러오지 못했습니다. 홈으로 돌아가 다시 시도해주세요.'),
+                    ),
+                  );
+                },
+                loading: () => const Scaffold(
+                  body: Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+                error: (error, stack) => Scaffold(
+                  body: Center(
+                    child: Text('일정을 불러오는 중 오류가 발생했습니다: $error'),
+                  ),
+                ),
+              );
+            },
+          );
         },
       ),
       GoRoute(


### PR DESCRIPTION
## Summary
- 일정 등록 라우트를 기존 위치 기반 편집 화면 대신 EditEventScreen으로 교체해 이벤트와 지오펜스를 한 화면에서 입력하도록 구성했습니다.
- 일정 수정 경로에서도 동일 화면을 재사용할 수 있도록 이벤트를 우선 조회하고, 기존 위치 일정만 있는 경우에는 임시 이벤트를 만들어 전달하는 안전장치를 추가했습니다.
- AppRepository에 ID로 이벤트를 찾는 보조 함수를 마련해 라우터에서 간결하게 기존 데이터를 검색할 수 있게 했습니다.

## Testing
- flutter test *(실행 불가: flutter 명령어를 사용할 수 없는 환경)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3936ee08325800f03bbd0ddd2e5