### PR TITLE
홈 화면 상단에 설정 및 가이드 버튼 배치

### DIFF
--- a/lib/features/home/life_battery_home_screen.dart
+++ b/lib/features/home/life_battery_home_screen.dart
@@ -113,6 +113,143 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
     }
   }
 
+  /// 홈 화면의 "가이드" 버튼을 눌렀을 때 호출된다.
+  ///
+  /// 초보자도 쉽게 따라올 수 있도록, 가장 많이 묻는 사용법을 정리한
+  /// 모달 바텀시트를 띄워 순차적으로 안내한다.
+  void _showGuideBottomSheet() {
+    // showModalBottomSheet에 넘겨줄 기본 컨텍스트를 미리 보관한다.
+    final rootContext = context;
+    showModalBottomSheet<void>(
+      context: rootContext,
+      showDragHandle: true, // 상단에 손잡이를 노출해 끌어내릴 수 있음을 알린다.
+      builder: (sheetContext) {
+        return SafeArea(
+          // 키보드가 올라와도 내용이 가려지지 않도록 SafeArea로 감싼다.
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '라이프 배터리 이용 가이드',
+                  style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                // 1단계: 일정 카드와 실행 버튼 소개
+                _guideItem(
+                  icon: Icons.play_circle_outline,
+                  title: '일정 실행',
+                  description:
+                      '오늘 일정 카드 우측의 ▶ 버튼을 누르면 해당 일정이 시작되고, 배터리가 자동으로 계산됩니다.',
+                ),
+                const SizedBox(height: 8),
+                // 2단계: 상세 화면 이동 안내
+                _guideItem(
+                  icon: Icons.menu_book_outlined,
+                  title: '상세 정보 확인',
+                  description:
+                      '일정 카드를 손가락으로 한 번 탭하면 상세 화면으로 이동하여 '
+                      '남은 시간과 메모를 더 자세히 확인할 수 있습니다.',
+                ),
+                const SizedBox(height: 8),
+                // 3단계: 위치 기반 일정과 권한 안내
+                _guideItem(
+                  icon: Icons.my_location,
+                  title: '위치 기반 일정 준비',
+                  description:
+                      '위치 기반 기능을 활용하려면 설정 화면에서 위치·알림 권한을 모두 허용해야 '
+                      '지오펜스가 정확히 동작합니다.',
+                ),
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: () {
+                    // 안내를 확인한 뒤 바로 설정 화면으로 이동할 수 있도록 구성한다.
+                    Navigator.of(sheetContext).pop();
+                    if (!mounted) return; // 사용자가 화면을 나간 경우를 대비
+                    rootContext.push('/settings');
+                  },
+                  icon: const Icon(Icons.settings),
+                  label: const Text('설정 화면으로 이동'),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// 가이드 바텀시트에 들어갈 한 줄 설명을 위젯으로 만들어 준다.
+  ///
+  /// [icon] : 각 단계의 주제를 직관적으로 보여줄 아이콘
+  /// [title] : 단계 제목
+  /// [description] : 세부 설명 (두 줄 이상이 될 수 있으므로 Expanded로 감싼다)
+  Widget _guideItem({
+    required IconData icon,
+    required String title,
+    required String description,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, color: const Color(0xFF3E82F7)),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                description,
+                style: const TextStyle(fontSize: 14, height: 1.4),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 상단 우측에 배치할 동그란 버튼을 재사용 가능한 형태로 생성한다.
+  Widget _headerActionButton({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    return TextButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, size: s(context, 16)),
+      label: Text(
+        label,
+        style: TextStyle(
+          fontSize: s(context, 12),
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      style: TextButton.styleFrom(
+        padding: EdgeInsets.symmetric(
+          horizontal: s(context, 12),
+          vertical: s(context, 6),
+        ),
+        backgroundColor: Colors.white.withOpacity(0.9),
+        foregroundColor: const Color(0xFF111118),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(s(context, 18)),
+        ),
+      ),
+    );
+  }
+
   /// 위치/알림 관련 권한을 순차적으로 요청한다.
   /// 초보자도 이해할 수 있도록 어떤 플랫폼에서 어떤 권한을 요구하는지 주석을 덧붙였다.
   Future<void> _requestPermissions() async {
@@ -482,6 +619,7 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
     final sectionTop = ringTop + ringSize + s(context, 0);
     final pageSide = s(context, 20);
     final listBottom = tabH + s(context, 8);
+    final actionTop = s(context, 20); // 상단 버튼과 제목 사이 여백 계산
 
     // 리스트 카드 스케일
     final iconBg = w * 0.12;
@@ -498,6 +636,31 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
       body: Stack(
         clipBehavior: Clip.none, // 배터리 링의 광채가 잘리면 안 되므로 none 유지
         children: [
+          // ------------------ 상단 설정/가이드 버튼 ------------------
+          Positioned(
+            top: actionTop,
+            right: pageSide,
+            child: SafeArea(
+              bottom: false, // 하단 여백은 필요 없으므로 false
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _headerActionButton(
+                    icon: Icons.help_outline,
+                    label: '가이드',
+                    onTap: _showGuideBottomSheet,
+                  ),
+                  SizedBox(width: s(context, 8)),
+                  _headerActionButton(
+                    icon: Icons.settings,
+                    label: '설정',
+                    onTap: () => context.push('/settings'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
           // ------------------ 제목 ------------------
           Positioned(
             top: titleTop,
@@ -782,15 +945,10 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
       children: [
         const Divider(height: 32),
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: [
             const Text('위치 기반 일정',
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-            IconButton(
-              tooltip: '설정',
-              onPressed: () => context.push('/settings'),
-              icon: const Icon(Icons.settings),
-            ),
           ],
         ),
         const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- 홈 상단 우측에 설정과 가이드 버튼을 배치하고 재사용 가능한 버튼 위젯으로 정리했습니다.
- 가이드 버튼에서 앱 사용법을 단계별로 안내하는 모달을 열고, 설정 화면으로 바로 이동할 수 있도록 연결했습니다.
- 위치 기반 일정 섹션의 중복 설정 아이콘을 제거해 상단 버튼과 역할을 통합했습니다.

## Testing
- flutter test *(실패: flutter 명령어를 찾을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f69af1fc8325ba1bb252be7ae286