### PR TITLE
홈 화면 가이드 버튼 제거

### DIFF
--- a/lib/features/home/life_battery_home_screen.dart
+++ b/lib/features/home/life_battery_home_screen.dart
@@ -6,16 +6,13 @@ import 'package:energy_battery/features/home/widgets/life_tab_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/scale.dart'; // 디자인 시안의 px 값을 기기 해상도에 맞게 변환하는 헬퍼
 import '../../data/models.dart'; // 기존 시간표(Event) 모델
 import '../../data/repositories.dart'; // 기존 이벤트/설정 저장소
-import '../../data/schedule_models.dart'; // 위치 기반 일정(Schedule) 모델
 import '../../data/schedule_repository.dart'; // 위치 기반 일정 레포지토리 프로바이더
-import '../../features/schedule/providers.dart'; // 위치 기반 일정 스트림 프로바이더
 import '../../services/geofence_manager.dart'; // 지오펜스 매니저 (동기화 담당)
 import '../../services/notifications.dart'; // 로컬 알림 서비스
 import 'battery_controller.dart'; // 배터리 퍼센트 관리 컨트롤러
@@ -111,113 +108,6 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
       // 지오펜스 준비는 필수는 아니므로, 실패하더라도 앱이 죽지 않도록 로그만 남긴다.
       debugPrint('지오펜스 준비 실패: $e');
     }
-  }
-
-  /// 홈 화면의 "가이드" 버튼을 눌렀을 때 호출된다.
-  ///
-  /// 초보자도 쉽게 따라올 수 있도록, 가장 많이 묻는 사용법을 정리한
-  /// 모달 바텀시트를 띄워 순차적으로 안내한다.
-  void _showGuideBottomSheet() {
-    // showModalBottomSheet에 넘겨줄 기본 컨텍스트를 미리 보관한다.
-    final rootContext = context;
-    showModalBottomSheet<void>(
-      context: rootContext,
-      showDragHandle: true, // 상단에 손잡이를 노출해 끌어내릴 수 있음을 알린다.
-      builder: (sheetContext) {
-        return SafeArea(
-          // 키보드가 올라와도 내용이 가려지지 않도록 SafeArea로 감싼다.
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '라이프 배터리 이용 가이드',
-                  style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-                const SizedBox(height: 12),
-                // 1단계: 일정 카드와 실행 버튼 소개
-                _guideItem(
-                  icon: Icons.play_circle_outline,
-                  title: '일정 실행',
-                  description:
-                      '오늘 일정 카드 우측의 ▶ 버튼을 누르면 해당 일정이 시작되고, 배터리가 자동으로 계산됩니다.',
-                ),
-                const SizedBox(height: 8),
-                // 2단계: 상세 화면 이동 안내
-                _guideItem(
-                  icon: Icons.menu_book_outlined,
-                  title: '상세 정보 확인',
-                  description:
-                      '일정 카드를 손가락으로 한 번 탭하면 상세 화면으로 이동하여 '
-                      '남은 시간과 메모를 더 자세히 확인할 수 있습니다.',
-                ),
-                const SizedBox(height: 8),
-                // 3단계: 위치 기반 일정과 권한 안내
-                _guideItem(
-                  icon: Icons.my_location,
-                  title: '위치 기반 일정 준비',
-                  description:
-                      '위치 기반 기능을 활용하려면 설정 화면에서 위치·알림 권한을 모두 허용해야 '
-                      '지오펜스가 정확히 동작합니다.',
-                ),
-                const SizedBox(height: 16),
-                FilledButton.icon(
-                  onPressed: () {
-                    // 안내를 확인한 뒤 바로 설정 화면으로 이동할 수 있도록 구성한다.
-                    Navigator.of(sheetContext).pop();
-                    if (!mounted) return; // 사용자가 화면을 나간 경우를 대비
-                    rootContext.push('/settings');
-                  },
-                  icon: const Icon(Icons.settings),
-                  label: const Text('설정 화면으로 이동'),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  /// 가이드 바텀시트에 들어갈 한 줄 설명을 위젯으로 만들어 준다.
-  ///
-  /// [icon] : 각 단계의 주제를 직관적으로 보여줄 아이콘
-  /// [title] : 단계 제목
-  /// [description] : 세부 설명 (두 줄 이상이 될 수 있으므로 Expanded로 감싼다)
-  Widget _guideItem({
-    required IconData icon,
-    required String title,
-    required String description,
-  }) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Icon(icon, color: const Color(0xFF3E82F7)),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                description,
-                style: const TextStyle(fontSize: 14, height: 1.4),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
   }
 
   /// 상단 우측에 배치할 동그란 버튼을 재사용 가능한 형태로 생성한다.
@@ -595,9 +485,6 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
       _remainMap.putIfAbsent(e.id, () => e.endAt.difference(e.startAt));
     }
 
-    // 위치 기반 일정 스트림을 구독한다. (AsyncValue<List<Schedule>>)
-    final schedulesAsync = ref.watch(scheduleStreamProvider);
-
     // ====== 시안 비율(가로 기준) ======
     final w = MediaQuery.of(context).size.width;
 
@@ -636,27 +523,17 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
       body: Stack(
         clipBehavior: Clip.none, // 배터리 링의 광채가 잘리면 안 되므로 none 유지
         children: [
-          // ------------------ 상단 설정/가이드 버튼 ------------------
+          // ------------------ 상단 설정 버튼 ------------------
           Positioned(
             top: actionTop,
             right: pageSide,
             child: SafeArea(
               bottom: false, // 하단 여백은 필요 없으므로 false
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  _headerActionButton(
-                    icon: Icons.help_outline,
-                    label: '가이드',
-                    onTap: _showGuideBottomSheet,
-                  ),
-                  SizedBox(width: s(context, 8)),
-                  _headerActionButton(
-                    icon: Icons.settings,
-                    label: '설정',
-                    onTap: () => context.push('/settings'),
-                  ),
-                ],
+              child: _headerActionButton(
+                // 가이드 버튼을 제거하고 설정 버튼만 노출하여 상단 액션을 간결하게 유지한다.
+                icon: Icons.settings,
+                label: '설정',
+                onTap: () => context.push('/settings'),
               ),
             ),
           ),
@@ -701,51 +578,31 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
             left: pageSide,
             right: pageSide,
             bottom: listBottom,
-            child: RefreshIndicator(
-              // 아래로 당겼을 때 위치 기반 일정을 다시 동기화한다.
-              onRefresh: () async {
-                final scheduleRepo = ref.read(scheduleRepositoryProvider);
-                try {
-                  await ref
-                      .read(geofenceManagerProvider)
-                      .syncSchedules(scheduleRepo.currentSchedules);
-                } catch (e) {
-                  debugPrint('위치 일정 동기화 실패: $e');
-                }
-                await _saveRemainMap(); // 기존 일정 남은 시간도 함께 저장
-              },
-              // AlwaysScrollableScrollPhysics를 사용하면 내용이 짧아도 당겨서 새로고침 가능
-              child: ListView(
-                padding: EdgeInsets.zero,
-                physics: const AlwaysScrollableScrollPhysics(),
-                children: [
-                  _todaySectionHeader(w),
-                  SizedBox(height: s(context, 8)),
-                  _todayList(
-                    repo,
-                    iconBg,
-                    iconSize,
-                    cardPadding,
-                    titleInCard,
-                    chipFs,
-                    timeFs,
-                    cardRadius,
-                    cardGap,
-                  ),
-                  SizedBox(height: s(context, 16)),
-                  // 위치 기반 일정 섹션: 로딩/에러/데이터 상태에 따라 다른 위젯을 그린다.
-                  schedulesAsync.when(
-                    loading: () => const Center(
-                      child: Padding(
-                        padding: EdgeInsets.symmetric(vertical: 24),
-                        child: CircularProgressIndicator(),
-                      ),
-                    ),
-                    error: (e, _) => _locationError(e),
-                    data: (schedules) => _locationScheduleSection(schedules),
-                  ),
-                ],
-              ),
+            child: ListView(
+              // 위치 기반 일정 리스트를 제거했더라도 스크롤이 갑자기 멈추지 않도록
+              // 항상 스크롤 가능한 물리 엔진(AlwaysScrollableScrollPhysics)을 유지한다.
+              padding: EdgeInsets.zero,
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                _todaySectionHeader(w),
+                SizedBox(height: s(context, 8)),
+                _todayList(
+                  repo,
+                  iconBg,
+                  iconSize,
+                  cardPadding,
+                  titleInCard,
+                  chipFs,
+                  timeFs,
+                  cardRadius,
+                  cardGap,
+                ),
+                SizedBox(height: s(context, 16)),
+                // 위치 기반 일정 카드 대신 배치할 수 있는 여백을 따로 확보한다.
+                // 지금은 단순한 공간이지만, 추후 다른 정보를 채우고 싶다면
+                // 아래 SizedBox 부분에 새 위젯을 추가하면 된다.
+                SizedBox(height: s(context, 24)),
+              ],
             ),
           ),
 
@@ -761,7 +618,8 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
                 alignment: Alignment.bottomCenter,
                 child: LifeTabBar(
                   onAdd: () async {
-                    // + 버튼은 위치 기반 일정 추가 화면으로 이동하도록 변경
+                    // 홈에서 리스트는 숨겼지만, + 버튼으로는 여전히 위치 기반 일정 생성 화면에 접근한다.
+                    // 위치 기반 자동 실행 기능은 유지해야 하므로 진입 경로를 없애지 않는다.
                     context.push('/schedule/new');
                   },
                   onClock: () async {
@@ -907,124 +765,6 @@ class _LifeBatteryHomeScreenState extends ConsumerState<LifeBatteryHomeScreen> {
     );
   }
 
-  // ---------- 위치 기반 일정: 에러 화면 ----------
-  Widget _locationError(Object err) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 24),
-      child: Column(
-        children: [
-          const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
-          const SizedBox(height: 8),
-          Text(
-            '위치 기반 일정을 불러오지 못했습니다\n$err',
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 8),
-          FilledButton(
-            onPressed: _prepareLocationSchedules,
-            child: const Text('권한 확인 및 다시 시도'),
-          )
-        ],
-      ),
-    );
-  }
-
-  // ---------- 위치 기반 일정 섹션 ----------
-  Widget _locationScheduleSection(List<Schedule> schedules) {
-    final now = DateTime.now();
-    final today = schedules
-        .where((s) => _isSameDay(s.startAt, now))
-        .toList(growable: false);
-    final upcoming = schedules
-        .where((s) => s.startAt.isAfter(now) && !_isSameDay(s.startAt, now))
-        .toList(growable: false);
-    final df = DateFormat('MM/dd HH:mm');
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Divider(height: 32),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            const Text('위치 기반 일정',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-          ],
-        ),
-        const SizedBox(height: 8),
-
-        if (schedules.isEmpty)
-          _emptyLocationPlaceholder()
-        else ...[
-          if (today.isNotEmpty) ...[
-            const Text('오늘', style: TextStyle(fontWeight: FontWeight.w600)),
-            const SizedBox(height: 6),
-            ...today.map((s) => _locationTile(s, df)),
-            const SizedBox(height: 12),
-          ],
-          const Text('다가오는 일정',
-              style: TextStyle(fontWeight: FontWeight.w600)),
-          const SizedBox(height: 6),
-          if (upcoming.isEmpty)
-            const Text('등록된 향후 일정이 없습니다. 아래 버튼으로 추가해보세요.'),
-          ...upcoming.map((s) => _locationTile(s, df)),
-          const SizedBox(height: 8),
-          FilledButton.icon(
-            onPressed: () => context.push('/schedule/new'),
-            icon: const Icon(Icons.add_location_alt_outlined),
-            label: const Text('위치 일정 추가'),
-          ),
-        ],
-      ],
-    );
-  }
-
-  // ---------- 위치 기반 일정이 하나도 없을 때 표시할 안내 ----------
-  Widget _emptyLocationPlaceholder() {
-    return Column(
-      children: [
-        const SizedBox(height: 8),
-        const Text('아직 위치 기반 일정이 없습니다.'),
-        const SizedBox(height: 8),
-        FilledButton.icon(
-          onPressed: () => context.push('/schedule/new'),
-          icon: const Icon(Icons.add_location_alt_outlined),
-          label: const Text('첫 일정 만들기'),
-        ),
-      ],
-    );
-  }
-
-  // ---------- 위치 기반 일정 카드 ----------
-  Widget _locationTile(Schedule s, DateFormat df) {
-    final radius = (s.radiusMeters ?? 150).toStringAsFixed(0);
-    final place = s.placeName ?? '좌표';
-    final useLoc =
-        s.useLocation ? '$place · 반경 ${radius}m' : '위치 사용 안 함';
-    return Card(
-      elevation: 1,
-      margin: const EdgeInsets.symmetric(vertical: 4),
-      child: ListTile(
-        title: Text(s.title),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('${df.format(s.startAt)} ~ ${df.format(s.endAt)}'),
-            Text(useLoc),
-            Text('트리거: ${s.triggerType.koLabel}, 조건: ${s.dayCondition.koLabel}'),
-          ],
-        ),
-        trailing: s.executed
-            ? const Icon(Icons.check_circle, color: Colors.green)
-            : const Icon(Icons.notifications_active, color: Colors.orange),
-        onTap: () => context.push('/schedule/${s.id}'),
-      ),
-    );
-  }
-
-  /// 두 날짜가 같은 날인지 비교하는 간단한 헬퍼
-  bool _isSameDay(DateTime a, DateTime b) =>
-      a.year == b.year && a.month == b.month && a.day == b.day;
 }
 
 // ===================== 일정 카드 =====================


### PR DESCRIPTION
## Summary
- 홈 화면 상단의 가이드 버튼과 관련 바텀시트 로직을 제거했습니다.
- 설정 버튼만 남기고 주석으로 변경 이유를 명시했습니다.
- 홈 화면에서 위치 기반 일정 리스트 UI와 보조 위젯을 제거해 화면을 단순화했습니다.

## Testing
- flutter test *(환경에 Flutter 명령어가 없어 실행 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3cec0fa8832580be777ab09b0866