### PR TITLE
안드로이드 정확한 알람 권한 처리 강화

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.energy_battery">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -7,6 +8,10 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission
+        android:name="android.permission.USE_EXACT_ALARM"
+        tools:targetApi="tiramisu" />
     <application
         android:label="energy_battery"
         android:name="io.flutter.app.FlutterApplication"


### PR DESCRIPTION
## Summary
- AndroidManifest에 정확한 알람 관련 권한을 선언하여 최신 OS 요구사항을 충족했습니다.
- 예약 알림 시 Android 12 이상에서 정확한 알람 권한을 확인하고, 거부 시 안내 알림과 폴백 모드를 적용했습니다.

## Testing
- 환경에 `flutter` 명령이 없어 실행하지 못했습니다.


------
https://chatgpt.com/codex/tasks/task_e_68cac7785d888325940d3085ca2a76ae