### PR TITLE
feat: 웹 호환 플랫폼 헬퍼 도입

### DIFF
--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:io'; // 플랫폼(OS) 정보를 확인하기 위한 표준 라이브러리
-
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:timezone/data/latest.dart' as tz; // 타임존 데이터 로드
 import 'package:timezone/timezone.dart' as tz; // 일정 시간 계산에 사용
+
+import 'platform/platform_helper.dart'; // 플랫폼 분기 처리를 위한 헬퍼
 
 @pragma('vm:entry-point')
 void notificationTapBackground(NotificationResponse response) {
@@ -118,7 +118,7 @@ class NotificationService {
     );
     var androidScheduleMode = AndroidScheduleMode.exactAllowWhileIdle;
 
-    if (Platform.isAndroid) {
+    if (platformHelper.isAndroid) {
       // Android 단말에서만 정확한 알람 권한을 확인하면 되므로 우선 안드로이드용 플러그인 인스턴스를 가져온다
       final androidPlugin = _plugin
           .resolvePlatformSpecificImplementation<
@@ -169,26 +169,9 @@ class NotificationService {
 
   /// 현재 단말의 안드로이드 SDK 버전을 반환한다. (다른 플랫폼은 null)
   Future<int?> _getAndroidSdkInt() async {
-    if (!Platform.isAndroid) {
-      return null; // Android가 아니라면 SDK 버전이 의미가 없으므로 null 처리
-    }
-
-    final versionString = Platform.operatingSystemVersion;
-
-    // 대표적인 문자열 예시: "Android 13 (API 33)"
-    final apiMatch =
-        RegExp('API(?:\\s+Level)?\\s*(\\d+)').firstMatch(versionString);
-    if (apiMatch != null) {
-      return int.tryParse(apiMatch.group(1)!); // 정규식에서 추출한 숫자를 정수로 변환
-    }
-
-    // 제조사에 따라 "SDK 33"과 같은 표현을 쓰기도 하므로 보조 정규식을 한 번 더 확인
-    final sdkMatch = RegExp('SDK\\s*(\\d+)').firstMatch(versionString);
-    if (sdkMatch != null) {
-      return int.tryParse(sdkMatch.group(1)!);
-    }
-
-    return null; // 어떤 패턴에도 맞지 않으면 null 반환하여 상위 로직에서 안전하게 처리
+    // 플랫폼 헬퍼가 알아서 안드로이드 여부와 SDK 버전을 판단한다.
+    // 웹이나 다른 플랫폼에서는 null이 반환되므로 호출부에서 안전하게 처리 가능하다.
+    return platformHelper.getAndroidSdkInt();
   }
 
   /// 예약된 알림 취소

--- a/lib/services/platform/platform_helper.dart
+++ b/lib/services/platform/platform_helper.dart
@@ -1,0 +1,7 @@
+import 'platform_helper_base.dart';
+import 'platform_stub.dart' if (dart.library.io) 'platform_io.dart';
+
+/// 조건부 임포트를 통해 실제 플랫폼에 맞는 구현체를 선택한다.
+///
+/// 다른 파일에서는 `platformHelper`만 가져다 쓰면 플랫폼 분기 처리가 자동으로 된다.
+final PlatformHelper platformHelper = getPlatformHelper();

--- a/lib/services/platform/platform_helper_base.dart
+++ b/lib/services/platform/platform_helper_base.dart
@@ -1,0 +1,11 @@
+/// 플랫폼 관련 공통 인터페이스를 정의한 파일
+///
+/// 웹/모바일 각각의 구현 파일에서 `PlatformHelper`를 구현하고,
+/// 조건부 임포트를 통해 적절한 구현을 사용할 수 있도록 분리한다.
+abstract class PlatformHelper {
+  /// 현재 플랫폼이 안드로이드인지 여부
+  bool get isAndroid;
+
+  /// 안드로이드 SDK 버전 (웹 및 비안드로이드 플랫폼에서는 null 반환)
+  Future<int?> getAndroidSdkInt();
+}

--- a/lib/services/platform/platform_io.dart
+++ b/lib/services/platform/platform_io.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'platform_helper_base.dart';
+
+/// `dart:io`를 사용할 수 있는 환경(안드로이드/iOS/데스크톱 등)에서의 구현체
+class IoPlatformHelper implements PlatformHelper {
+  @override
+  bool get isAndroid => Platform.isAndroid; // 안드로이드 단말인지 직접 확인
+
+  @override
+  Future<int?> getAndroidSdkInt() async {
+    if (!Platform.isAndroid) {
+      // 안드로이드가 아니라면 SDK 버전 자체가 의미가 없으므로 null 반환
+      return null;
+    }
+
+    final versionString = Platform.operatingSystemVersion;
+
+    // 대표적인 문자열 예시: "Android 13 (API 33)"
+    final apiMatch =
+        RegExp('API(?:\\s+Level)?\\s*(\\d+)').firstMatch(versionString);
+    if (apiMatch != null) {
+      // 정규식에서 추출한 숫자를 정수로 변환하여 반환
+      return int.tryParse(apiMatch.group(1)!);
+    }
+
+    // 제조사에 따라 "SDK 33"과 같은 표현을 쓰기도 하므로 보조 정규식을 한 번 더 확인
+    final sdkMatch = RegExp('SDK\\s*(\\d+)').firstMatch(versionString);
+    if (sdkMatch != null) {
+      return int.tryParse(sdkMatch.group(1)!);
+    }
+
+    return null; // 어떤 패턴에도 맞지 않으면 null 반환하여 상위 로직에서 안전하게 처리
+  }
+}
+
+/// 조건부 임포트에서 사용할 헬퍼 생성 함수
+PlatformHelper getPlatformHelper() => IoPlatformHelper();

--- a/lib/services/platform/platform_stub.dart
+++ b/lib/services/platform/platform_stub.dart
@@ -1,0 +1,16 @@
+import 'platform_helper_base.dart';
+
+/// 웹을 비롯한 `dart:io`가 사용 불가능한 환경에서 사용할 구현체
+class WebPlatformHelper implements PlatformHelper {
+  @override
+  bool get isAndroid => false; // 웹에서는 절대 안드로이드가 아니므로 false 고정
+
+  @override
+  Future<int?> getAndroidSdkInt() async {
+    // 웹에서는 안드로이드 SDK 개념이 없으므로 null 반환
+    return null;
+  }
+}
+
+/// 조건부 임포트에서 사용할 헬퍼 생성 함수
+PlatformHelper getPlatformHelper() => WebPlatformHelper();


### PR DESCRIPTION
## Summary
- 웹 환경에서도 컴파일할 수 있도록 dart:io 직접 의존성을 플랫폼 헬퍼로 교체했습니다.
- 플랫폼 헬퍼에 안드로이드 여부 및 SDK 버전 조회 기능을 구현하고 웹에서는 안전하게 기본값을 반환하도록 구성했습니다.
- NotificationService에서 새 헬퍼를 사용하도록 수정하면서 관련 주석을 보강했습니다.

## Testing
- 미실행 (실행 환경에 Flutter 명령어가 없어 빌드/테스트를 수행할 수 없습니다)


------
https://chatgpt.com/codex/tasks/task_e_68cad487e7248325a164e8876a203d9b