### PR TITLE
스플래시 화면 도입 및 홈 라우트 분리

### DIFF
--- a/lib/features/schedule/schedule_detail_screen.dart
+++ b/lib/features/schedule/schedule_detail_screen.dart
@@ -36,7 +36,9 @@ class ScheduleDetailScreen extends ConsumerWidget {
             if (context.canPop()) {
               context.pop();
             } else {
-              context.go('/');
+              // ▼ 홈 경로가 '/home'으로 바뀌었으므로, 뒤로가기 실패 시 새 경로로 안내한다.
+              //    이렇게 하면 스플래시('/')를 거치지 않고 바로 실제 홈 화면으로 돌아간다.
+              context.go('/home');
             }
           },
         ),
@@ -139,7 +141,9 @@ class ScheduleDetailScreen extends ConsumerWidget {
       if (context.canPop()) {
         context.pop();
       } else {
-        context.go('/');
+        // ▼ 삭제 후에도 이전 화면이 없으면 '/home'으로 이동해 사용자가 길을 잃지 않도록 한다.
+        //    스플래시용 '/' 경로로 보내면 다시 로고를 보게 되므로 새 홈 경로를 사용한다.
+        context.go('/home');
       }
     }
   }

--- a/lib/features/schedule/schedule_edit_screen.dart
+++ b/lib/features/schedule/schedule_edit_screen.dart
@@ -101,7 +101,9 @@ class _ScheduleEditScreenState extends ConsumerState<ScheduleEditScreen> {
             if (context.canPop()) {
               context.pop();
             } else {
-              context.go('/');
+              // ▼ 스플래시 도입으로 실제 홈 화면 경로가 '/home'으로 변경되었다.
+              //    루트('/')는 스플래시가 차지하므로, 홈으로 돌아가려면 '/home'을 호출해야 한다.
+              context.go('/home');
             }
           },
         ),
@@ -419,7 +421,9 @@ class _ScheduleEditScreenState extends ConsumerState<ScheduleEditScreen> {
     if (context.canPop()) {
       context.pop();
     } else {
-      context.go('/');
+      // ▼ 저장 후 사용자를 다시 홈으로 돌려보낼 때도 새 경로 '/home'을 사용한다.
+      //    이렇게 해두면 스플래시 화면을 다시 보지 않고 곧바로 홈으로 복귀한다.
+      context.go('/home');
     }
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -128,7 +128,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
             if (context.canPop()) {
               context.pop();
             } else {
-              context.go('/');
+              // ▼ 홈 경로가 '/home'으로 이동했으므로, 루트('/') 대신 새 경로를 사용한다.
+              //    스플래시 화면을 다시 보지 않게 하고 바로 홈으로 돌아가도록 돕는다.
+              context.go('/home');
             }
           },
         ),

--- a/lib/features/splash/splash_screen.dart
+++ b/lib/features/splash/splash_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// 앱을 처음 켰을 때 1초 동안 로고를 보여준 뒤 홈으로 이동하는 스플래시 화면.
+/// 초보자도 이해할 수 있도록, 각 단계마다 어떤 일이 일어나는지 한글 주석을 최대한 자세히 작성한다.
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // ▼ 앱 시작 시 1초 동안 로고만 보여주기 위해 Future.delayed를 사용한다.
+    //    Duration(seconds: 1)을 주면 1초가 지난 뒤에 콜백이 실행된다.
+    Future.delayed(const Duration(seconds: 1), () {
+      // ▼ Future가 실행되는 동안 사용자가 다른 화면으로 이동하면 context가 사라질 수 있으므로,
+      //    mounted 여부를 확인하여 안전하게 라우팅을 진행한다.
+      if (!mounted) return;
+
+      // ▼ 준비된 홈 화면은 '/home' 경로에 연결해 두었으므로, 스플래시 종료 시 그쪽으로 이동한다.
+      //    go_router의 context.go는 현재 화면을 대체하고 새 라우트를 스택 최상단으로 만든다.
+      context.go('/home');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        // ▼ 기존 자산 폴더에 있는 앱 로고 이미지를 사용해 사용자가 앱을 알아볼 수 있도록 한다.
+        //    Image.asset은 pubspec.yaml에 등록된 자산을 읽어온다.
+        child: Image.asset(
+          'assets/icon/app_icon.png',
+          width: 120,
+          height: 120,
+          fit: BoxFit.contain,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'features/settings/settings_screen.dart';
 import 'features/task/task_screen.dart';
 import 'features/home/event_list_screen.dart';
 import 'features/report/report_screen.dart';
+import 'features/splash/splash_screen.dart';
 import 'services/geofence_manager.dart';
 import 'services/holiday_service.dart';
 import 'services/notifications.dart';
@@ -76,14 +77,25 @@ void main() async {
 
 final routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
+    // ▼ initialLocation을 '/'로 유지하면, 앱이 켜졌을 때 가장 먼저 스플래시 화면이 보인다.
+    //    이후 스플래시에서 context.go('/home')을 호출해 실제 홈 화면으로 이동하도록 구성했다.
+    initialLocation: '/',
     routes: [
       GoRoute(
         path: '/',
+        name: 'splash',
+        builder: (context, state) {
+          // ▼ '/' 경로는 이제 스플래시 화면을 담당한다.
+          //    앱 실행 직후 1초 동안 로고를 보여준 뒤 '/home'으로 이동하도록 구성했다.
+          return const SplashScreen();
+        },
+      ),
+      GoRoute(
+        path: '/home',
         name: 'home',
         builder: (context, state) {
-          // ▼ 초보자도 이해하기 쉽게: 앱을 켰을 때 가장 먼저 보이는 화면을 지정한다.
-          //    기존에는 일정 홈(ScheduleHomeScreen)으로 이동했지만,
-          //    요청에 따라 라이프 배터리 홈(LifeBatteryHomeScreen)을 기본 화면으로 교체했다.
+          // ▼ 실제 홈 UI는 '/home' 경로에 배치했다.
+          //    스플래시에서 context.go('/home')으로 이동하므로, 사용자는 자연스럽게 홈을 보게 된다.
           return const LifeBatteryHomeScreen();
         },
       ),


### PR DESCRIPTION
## Summary
- 1초 동안 로고를 보여준 뒤 홈으로 이동하는 스플래시 화면을 추가했습니다.
- GoRouter를 '/' 스플래시와 '/home' 실제 홈으로 나누고 경로 변경 이유를 주석으로 정리했습니다.
- 홈 복귀 시 사용하는 context.go 호출들을 '/home'으로 맞추고 새 흐름을 설명하는 주석을 덧붙였습니다.

## Testing
- Not run (Dart/Flutter 명령어가 컨테이너에 설치되어 있지 않음)


------
https://chatgpt.com/codex/tasks/task_e_68e00b0489e083259da6cd8b9fed525f